### PR TITLE
Fix bug where scene would not stop after either player or enemy dies.

### DIFF
--- a/Game/LifeQuest/enemy.gd
+++ b/Game/LifeQuest/enemy.gd
@@ -7,22 +7,28 @@ var enemyAttackStat = 2 # Temporary attack value. Pull value from where enemy ch
 var playerAttack = 1 # Temporary value for player attack stat.
 
 var attackCooldown = false
+var enemyIsAlive = true
 
 func _physics_process(delta):
-	_on_enemy_hit()
-	
-	if enemyHealthStat <= 0:
-		print("Enemy is dead.")
-		self.queue_free() 
+	pass
 	
 # Method that handles player attacks/health calculations
-func _on_enemy_hit():
+func on_hit():
 	if attackCooldown == false:
 		print("Enemy is being hit.")
 		attackCooldown = true
 		$enemyCooldown.start()
+		enemyHealthStat = enemyHealthStat - playerAttack
+		print("Enemy health is: " + str(enemyHealthStat))
 		
-		enemyHealthStat = enemyHealthStat - playerAttack	
+	if enemyHealthStat <= 0:
+		enemyIsAlive = false
 
 func _on_enemy_cooldown_timeout():
 	attackCooldown = false # Timer has finished and enemy may take damage again
+	
+func enemy_health():
+	return enemyHealthStat
+
+func is_alive():
+	return enemyIsAlive

--- a/Game/LifeQuest/enemy.tscn
+++ b/Game/LifeQuest/enemy.tscn
@@ -20,7 +20,6 @@ texture = ExtResource("1_yq8xx")
 shape = SubResource("CircleShape2D_trdnp")
 
 [node name="enemyCooldown" type="Timer" parent="."]
+wait_time = 0.5
 
-[connection signal="body_entered" from="enemyHitbox" to="." method="_on_enemy_hitbox_body_entered"]
-[connection signal="body_exited" from="enemyHitbox" to="." method="_on_enemy_hitbox_body_exited"]
 [connection signal="timeout" from="enemyCooldown" to="." method="_on_enemy_cooldown_timeout"]

--- a/Game/LifeQuest/moc9B7C.tmp
+++ b/Game/LifeQuest/moc9B7C.tmp
@@ -12,19 +12,3 @@ position = Vector2(293, 355)
 
 [node name="enemy" parent="." instance=ExtResource("3_wo41g")]
 position = Vector2(966, 360)
-
-[node name="UI" type="Node" parent="."]
-
-[node name="Win" type="Label" parent="UI"]
-offset_left = 556.0
-offset_top = 346.0
-offset_right = 629.0
-offset_bottom = 369.0
-text = "You Win!!"
-
-[node name="Lose" type="Label" parent="UI"]
-offset_left = 542.0
-offset_top = 346.0
-offset_right = 642.0
-offset_bottom = 369.0
-text = "you suck!! >:("

--- a/Game/LifeQuest/mock_game_scene.gd
+++ b/Game/LifeQuest/mock_game_scene.gd
@@ -1,9 +1,32 @@
 extends Node2D
 
+@onready var player = $player # Variable to access "player" child node
+@onready var playerHealth = $player.player_health 
+@onready var enemy = $enemy # Variable to access "enemy" child node
+@onready var enemyHealth = $enemy.enemy_health
+
+
 # Called when the node enters the scene tree for the first time.
 func _ready():
-	pass # Replace with function body.
+	get_node("UI/Lose").hide()
+	get_node("UI/Win").hide()
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.
 func _process(delta):
-	pass
+	
+	if player.is_alive() and enemy.is_alive() : # Checking if both entities are still alive. If still alive, continue attacking.
+		player.on_hit()
+		enemy.on_hit()
+	
+	if player.is_alive() and enemy.is_alive() == false: # If player is alive and enemy is dead.
+		print("Enemy is dead.")
+		enemy.queue_free()
+		get_node("UI/Win").show()
+		get_tree().paused = true
+		
+	if player.is_alive() == false and enemy.is_alive(): # If player is dead and enemy is alive.
+		print("Player is dead.")
+		player.queue_free()
+		get_node("UI/Lose").show()
+		get_tree().paused = true
+	

--- a/Game/LifeQuest/player.gd
+++ b/Game/LifeQuest/player.gd
@@ -9,25 +9,25 @@ var playerIsAlive = true
 var enemyAttack = 5 # Temporary value for enemy attack stat.
 
 func _physics_process(delta):
-	_enemy_is_attacking()
-	
-	# Checking for if player is still alive
-	if playerHealthStat <= 0: # If player health is less than or equal to 0, player is no longer alive
-		print("Player is dead.")
-		playerIsAlive = false
-		self.queue_free()
+	pass
 
 # Method that handles enemy attacks/health calculations
-func _enemy_is_attacking():
+func on_hit():
 	if attackCooldown == false:
 		print("Player is being hit.")
 		attackCooldown = true  # cooldown timer is active, cannot take another hit until timer is up
 		$cooldown.start() # Player cannot be hit for another 3 seconds
-		
 		playerHealthStat = playerHealthStat - enemyAttack
+		print("Player health is: " + str(playerHealthStat))
+		
+	if playerHealthStat <= 0: # If player health is less than or equal to 0, player is no longer alive
+		playerIsAlive = false
 
 func _on_cooldown_timeout():
 	attackCooldown = false # Resetting cooldown flag back to false once timer is up
 
-func _player_health():
+func player_health():
 	return playerHealthStat
+	
+func is_alive():
+	return playerIsAlive

--- a/Game/LifeQuest/player.tscn
+++ b/Game/LifeQuest/player.tscn
@@ -20,7 +20,6 @@ texture = ExtResource("2_jk87f")
 shape = SubResource("CircleShape2D_kyxv3")
 
 [node name="cooldown" type="Timer" parent="."]
-wait_time = 2.0
 
 [connection signal="body_entered" from="playerHitbox" to="." method="_on_player_hitbox_body_entered"]
 [connection signal="body_exited" from="playerHitbox" to="." method="_on_player_hitbox_body_exited"]


### PR DESCRIPTION
## Overview
Fixes bug where scene does not stop after either player or enemy dies.

## Related Issue(s)
Closes #55 

## Changes
Added health checks within the test game scene to only call player and enemy attacking functions if opposing entity is still alive. If no longer alive, the scene will PAUSE and display the appropriate winning/losing message. 

### Added
- Game scene will display a winning or losing message depending on if the player or enemy dies.
- Enemy script now has methods that will return their health and if they are alive from their own script 

### Changed
- Moved on_hit() (methods that control attack/damage calculations) from player and enemy scripts to be run from the game scene's script instead. Methods were previously called within their respective scripts.

### Fixed
- Scene pauses after either player or enemy dies.

## Screenshots
![image](https://github.com/UNLV-CS472-672/2024-S-GROUP7-LifeQuest/assets/99180260/e036da81-e35a-423b-8b8c-f6b02424c9cf)
![image](https://github.com/UNLV-CS472-672/2024-S-GROUP7-LifeQuest/assets/99180260/73276c8d-8c3a-4312-9988-77182cfcd1e4)

## Instructions for Testing
1. Open mock_test_scene.tscn in Godot project and run that scene specifically with this button.
![image](https://github.com/UNLV-CS472-672/2024-S-GROUP7-LifeQuest/assets/99180260/92a5253d-22cc-4f84-b3a7-e608237b3b59)


## Checklist before Merging
- [X] I have performed a self-review of my own code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [X] I have added necessary documentation (if appropriate).
- [X] I have ensured the changes adhere to the project's coding standards and guidelines.
