### PR TITLE
Added two tests to SettingsPage.test.js

### DIFF
--- a/app/src/tests/SettingsPage.test.js
+++ b/app/src/tests/SettingsPage.test.js
@@ -2,11 +2,13 @@
 // Converstaion Link: https://chat.openai.com/share/c8cda0b5-99fb-444d-998a-f630a96a52af
 
 import React from 'react';
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
+import axios from 'axios';
 import SettingsPage from '../pages/settings/SettingsPage';
 import '@testing-library/jest-dom/extend-expect';
 import styles from '../pages/settings/SettingsPage.module.css';
 
+jest.mock('axios');
 jest.mock('../contexts/FontSizeContext', () => ({
   useFontSize: () => ({
     fontSize: 16, 
@@ -77,4 +79,42 @@ describe('SettingsPage Component', () => {
 	});
 
 
+// Start of ChatGPT code (Antonio Tessier) 
+// Conversation link -> https://chat.openai.com/share/4bea6d17-2817-454e-94ad-04bd2e9f0c8d
+
+	it('runs delete account temporary function when delete account button is clicked', async () => {
+		const { getByText } = render(<SettingsPage />);
+		const deleteAccountButton = getByText('Delete Account');
+
+		fireEvent.click(deleteAccountButton);
+
+		// Ensure that handleDeleteAccountClick is called
+		await waitFor(() => {
+			expect(axios.post).toHaveBeenCalled();
+		});
+	});
+
+	it('handles unauthorized error correctly', async () => {
+		// Mock axios post function to return an error
+		axios.post.mockRejectedValue({ response: { status: 401 } });
+
+		const { getByText } = render(<SettingsPage />);
+		const deleteAccountButton = getByText('Delete Account');
+
+	        const url = "http://localhost:3000.com";     // <- Fernando's code
+	    
+	        Object.defineProperty(window, 'location', {  // <- Fernando's code
+	          value: {
+		    href: url
+	          }
+	        });	
+		
+		fireEvent.click(deleteAccountButton);
+
+		// Ensure user is redirected to login page on unauthorized error
+		await waitFor(() => {
+			expect(window.location.href).toBe('/');
+		});
+	});
+// End of ChatGPT code.
 });


### PR DESCRIPTION
## Overview
Added two tests regarding account deletion and unauthorized user errors.  These two tests cover lines 28 - 39, leaving only line 27 as uncovered.

ChatGPT was used to develop these tests.
[https://chat.openai.com/share/4bea6d17-2817-454e-94ad-04bd2e9f0c8d](https://chat.openai.com/share/4bea6d17-2817-454e-94ad-04bd2e9f0c8d)

## Related Issue(s)
Closes #111.

### Added
- Two new tests in SettingsPage.test.js.
  - Lines  82-120
- Two imports (axios, waitFor from react)

### Fixed
- SettingsPage Line Coverage is now 93%.
  - Up from 66%.
  - Total Line Coverage 91.9% -> 93.52%

## Screenshots

![image](https://github.com/UNLV-CS472-672/2024-S-GROUP7-LifeQuest/assets/147963318/d35281b3-724c-4949-9165-56d74ae0bb98)


## Checklist before Merging
- [x] I have performed a self-review of my own code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate).
- [x] I have ensured the changes adhere to the project's coding standards and guidelines.

## Additional Comments
- If anyone wants to suggest an edit to cover 27, feel free to let me know.
